### PR TITLE
Add new translations and keys for football stats and UI

### DIFF
--- a/base_languages/ckb.json
+++ b/base_languages/ckb.json
@@ -473,6 +473,11 @@
       "english": "Season stats",
       "value": "ئامارەکانی وەرز"
     },
+    "accessibility_goal_diff_title": {
+      "comment": "Label for goal difference stat (goals scored minus goals conceded).",
+      "english": "Goal difference",
+      "value": "جیاوازی گۆڵ"
+    },
     "accessibility_goal_type": {
       "comment": "Used for goal types in player profile",
       "english": "Goal type",
@@ -2444,6 +2449,11 @@
       "english": "xG + xA per 90",
       "value": "xG + xA بۆ هەر 90 خولەکێک"
     },
+    "accessibility_xg_diff_title": {
+      "comment": "Label for expected goals difference stat. Keep xG untranslated.",
+      "english": "xG difference",
+      "value": "جیاوازی xG"
+    },
     "accessibility_yellow": {
       "comment": "Used to describe yellow cards in the stats for player profile.",
       "english": "Yellow",
@@ -3345,6 +3355,21 @@
       "comment": "A label for number of errors a player has made that resulted in a goal for the opposition",
       "english": "Errors led to goal",
       "value": "هەڵەکان کە دەبنە هۆی گۆڵ لێکران"
+    },
+    "common_estimated_transfer_value_description": {
+      "comment": "The description for the graph we are displaying about estimated transfer value - This is a full breakdown of how estimated transfer value is calculated. Don't translate \"(ETV)\"",
+      "english": "Estimated Transfer Value (ETV) is our best guess of what a player would be worth if they were sold right now.\\n\\nIt’s calculated using real transfer data and takes into consideration:\\n\\n• player performance\\n• their age and future potential\\n• how often and at what level they play their position\\n• the strength of their team and league\\n• how long their contract still runs\\n• recent development and similar factors\\n\\nWe focus on the player themselves, not rumours, or which club might buy them.\\n\\nThe value is updated regularly to reflect changes in the transfer market over time.",
+      "value": "بەهای خەمڵێنراوی گواستنەوە (ETV) باشترین پێشبینی ئێمەیە بۆ نرخی یاریزانێک ئەگەر هەر ئێستا بفرۆشرێت.\\n\\nئەم بەهایە بە بەکارهێنانی داتای ڕاستەقینەی گواستنەوەکان هەژمار دەکرێت و ڕەچاوی ئەم خاڵانە دەکات:\\n\\n• ئاستی یاریزان\\n• تەمەن و توانای داهاتووی یاریزان\\n• چەند جار و لە چ ئاستێکدا لە پێگەکەی خۆیدا یاری دەکات\\n• هێزی یانە و خولەکەی\\n• ماوەی ماوە لە گرێبەستەکەی\\n• گەشەسەندنی ئەم دواییانە و هۆکارە هاوشێوەکان\\n\\nئێمە جەخت لەسەر خودی یاریزانەکە دەکەینەوە، نەک دەنگۆکان یان ئەوەی کام یانە لەوانەیە بییانکڕێت.\\n\\nبەهاکە بە شێوەیەکی خولی نوێ دەکرێتەوە بۆ ڕەنگدانەوەی گۆڕانکاریەکانی بازاڕی گواستنەوە بە تێپەڕبوونی کات."
+    },
+    "common_estimated_transfer_value_header": {
+      "comment": "A cell header for a Estimated transfer value graph. Showing the estimated transfer values for a player across his career",
+      "english": "Estimated transfer value",
+      "value": "بەهای خەمڵێنراوی گواستنەوە"
+    },
+    "common_estimated_transfer_value_subheader": {
+      "comment": "Subheader for the estimated transfer value cell. Providing a brief description about the meaning of estimated transfer value",
+      "english": "Likely value if sold now",
+      "value": "بەهای پێشبینیکراو ئەگەر ئێستا بفرۆشرێت"
     },
     "common_euro2016_onboarding_desc_line1": {
       "comment": "Onboarding: first line in adv.-alert",
@@ -9458,6 +9483,11 @@
       "english": "Clear lineup",
       "value": "سڕینەوەی پێکهاتە"
     },
+    "seo_code_copied_to_clipboard": {
+      "comment": "Toast message shown when user has copied the league code to clipboard",
+      "english": "Code copied to clipboard",
+      "value": "کۆدەکە کۆپی کرا بۆ کلیپبۆرد"
+    },
     "seo_competitions": {
       "comment": "Title for section listing competitions in the predictor game.",
       "english": "Competitions",
@@ -9472,6 +9502,11 @@
       "comment": "Description in popup prompting the user to either continue in the app or stay in the browser version of FotMob.",
       "english": "Continue in the FotMob app for a faster, better experience - for free!",
       "value": "لە ناو بەرنامەی فوتمۆبدا بەردەوام بە بۆ ئەزموونێکی خێراتر و باشتر - بەخۆڕایی!"
+    },
+    "seo_contract_end": {
+      "comment": "Label for the contract end date/expire date for a football player with his club.",
+      "english": "Contract end",
+      "value": "کۆتایی گرێبەست"
     },
     "seo_copied_link_web": {
       "comment": "Text in a button after completed copying the link of the linup builder team. see [copy_link_web].",
@@ -9578,6 +9613,11 @@
       "english": "Customize your homescreen with alternate app icons.",
       "value": "شاشەی مۆبایلەکەت بڕازێنەرەوە بە ئایکۆنە جیاوازەکانی بەرنامەکە."
     },
+    "seo_expected_goals_against_while_on_pitch": {
+      "comment": "Label for statistic showing expected goals against while being on the pitch. Keep xG as is, don't translate it.",
+      "english": "xG against while on pitch",
+      "value": "xG یانەی بەرامبەر لە کاتی یاریکردندا"
+    },
     "seo_expected_return_date_about_1_2_weeks": {
       "comment": "A text describing for how long a player is out injured or absent.",
       "english": "About 1-2 weeks",
@@ -9659,6 +9699,11 @@
       "english": "1st leg",
       "value": "یاری چوون"
     },
+    "seo_fixture_difficulty": {
+      "comment": "Label for a section showing the fixture difficulty for a football team. Indicates how hard the five next league matches are. Use a natural term that fits the local language i.e. match program, fixtures, calendar, or a different term. Doesn't necessarily *need* the term difficulty if it is a hard fit in that language. (Like norwegian it's OK to just use \"Kampprogram\")",
+      "english": "Fixture difficulty",
+      "value": "خشتەی سەختی یاریەکان"
+    },
     "seo_followed_leagues": {
       "comment": "Header for the list of leagues you are following.",
       "english": "Followed leagues",
@@ -9734,6 +9779,11 @@
       "english": "Get the best mobile experience",
       "value": "باشترین ئەزموونی مۆبایل بەدەست بهێنە"
     },
+    "seo_goals_conceded_while_on_pitch": {
+      "comment": "Label for statistic showing how many goals a player has conceded while being on the pitch. See goals_conceded",
+      "english": "Goals conceded while on pitch",
+      "value": "گۆڵ لێکران کاتێک یاریزانەکە لە یاریگادایە"
+    },
     "seo_gold": {
       "comment": "Title for \"gold medal\". User gets \"Gold\" when they predict correct outcome and score.",
       "english": "Gold",
@@ -9793,6 +9843,16 @@
       "comment": "Used for radio button in troubleshooting mail for choosing type of issue.",
       "english": "I need help",
       "value": "پێویستم بە یارمەتیە"
+    },
+    "seo_in_app_browser_warning_headline": {
+      "comment": "Short headline shown in an embedded in-app browser. It warns users that login may not work correctly in this environment.",
+      "english": "Login may not work in this in-app browser",
+      "value": "ڕەنگە چوونە ناوەوە لەم وێبگەڕەی ناو بەرنامەدا کار نەکات"
+    },
+    "seo_in_app_browser_warning_subline": {
+      "comment": "Supporting text that instructs users to open the page in their device’s default system browser to complete authentication.",
+      "english": "Please open this page in your device’s browser (Safari or Chrome) to continue.",
+      "value": "تکایە بۆ بەردەوامبوون، ئەم لاپەڕەیە لە وێبگەڕی ئامێرەکەتدا (سافاری یان گووگڵ کرۆم) بکەرەوە."
     },
     "seo_join_fotmob_plus_monthly": {
       "comment": "Description highligthing the price of the monthly FotMob+ subscription. i.e. \"Join FotMob+ for $4.99 / month\"",
@@ -9884,6 +9944,11 @@
       "english": "This live commentary has been auto-translated. There may be minor inaccuracies.",
       "value": "ئەم بێژەریە ڕاستەوخۆیە بە شێوەیەکی ئۆتۆماتیکی وەرگێڕدراوە. ڕەنگە هەندێک هەڵەی بچووکی تێدابێت."
     },
+    "seo_ltc_new_updates": {
+      "comment": "\"Toast\" used in live ticker commentary when user has scrolled down and there are new updates on the top of the page.",
+      "english": "New updates",
+      "value": "زانیاری نوێ"
+    },
     "seo_manage": {
       "comment": "Used for manage button on the FotMob+ member page.",
       "english": "Manage",
@@ -9914,6 +9979,11 @@
       "english": "Men",
       "value": "پیاوان"
     },
+    "seo_min_value_filter": {
+      "comment": "Label for a filter input where the user can set a value for players shown in a transfers list. Should cover both minimum market value and minimum transfer fee. Keep it short.",
+      "english": "Min value",
+      "value": "کەمترین بەها"
+    },
     "seo_minutes_countdown": {
       "comment": "see [available_in]. A label below a number indicating how many minutes left til the next week tournament use the plural form in the given language.",
       "english": "Minutes",
@@ -9938,6 +10008,11 @@
       "comment": "A header indicating you can sign up for a newsletter where we send emails to the user about football things.",
       "english": "Newsletter",
       "value": "هەواڵ نامە"
+    },
+    "seo_next_five_matches": {
+      "comment": "Label for a section showing the next five matches for a football team. See next_match",
+      "english": "Next five matches",
+      "value": "پێنج یاری داهاتوو"
     },
     "seo_no_matches_today_playing": {
       "comment": "A label indicating that none of the teams or leagues you follow are playing today. Above this label it says \"Following\" so this is already in the context of teams or leagues you follow.",
@@ -10009,10 +10084,30 @@
       "english": "<b>Official data.</b> These are the same physical stats trusted by professional teams.",
       "value": "<b>داتا فەڕمیەکان.</b> ئەمانە هەمان ئەو ئامارە جەستەییانەن کە یانە پیشەگەرەکان پشتی پێ دەبەستن."
     },
+    "seo_onboarding_wear_button": {
+      "comment": "Button for opening the Play Store when user sees Wear onboarding",
+      "english": "Get the Wear app",
+      "value": "بەرنامەی Wear بەدەستبهێنە"
+    },
+    "seo_onboarding_wear_subtitle": {
+      "comment": "Subtitle for showing the wear onboarding for users who has wear connected but yet not installed the FotMob app on wear",
+      "english": "Easily see match events, stats, and more for the teams you follow, with FotMob on your watch.",
+      "value": "بە ئاسانی ڕووداوەکانی یاری، ئامار و زانیاری ئەو یانانە ببینە کە بەدواداچوونیان بۆ دەکەیت، لە ڕێگەی فۆتمۆب لەسەر کاتژمێرەکەت."
+    },
+    "seo_onboarding_wear_title": {
+      "comment": "Title for showing the wear onboarding for users who has wear connected but yet not installed the FotMob app on wear",
+      "english": "All the action, right from your wrist.",
+      "value": "هەموو ڕوداوەکان ڕاستەوخۆ، لەسەر دەستت ببینە."
+    },
     "seo_overwrite": {
       "comment": "toast text option to overwrite a saved lineup.",
       "english": "Overwrite",
       "value": "جێبەجێکردن"
+    },
+    "seo_participants_count": {
+      "comment": "Label showing how many participants/members are in your mini-league. %1$@ is replaced with the number of participants. Don't support plural differences.",
+      "english": "%1$@ participants",
+      "value": "%1$@ بەشداربوو"
     },
     "seo_penalty_shootout": {
       "comment": "Used in notifications for indicating penalty shootout like \"Arsenal scores! (penalty shootout)\".",
@@ -10169,10 +10264,20 @@
       "english": "Pre-fill with popular teams",
       "value": "پڕکردنەوە بە تیمە بەناوبانگەکان"
     },
+    "seo_predict_copy_code": {
+      "comment": "Button label for copying your league code to clipboard so you can share it with others to join your mini-league. See predict_league_code",
+      "english": "Copy code",
+      "value": "کۆدەکە کۆپی بکە"
+    },
     "seo_predict_edit_until_kick_off": {
       "comment": "Text for the second step in the predictor game, to explain that you can edit your predictions until the match starts.",
       "english": "You can edit your predictions until the match kicks off.",
       "value": "دەتوانیت پێشبینیەکانت دەستکاری بکەیت تا ئەو کاتەی یاریەکە دەست پێ دەکات."
+    },
+    "seo_predict_league_code": {
+      "comment": "Label for your league's unique code that can be shared with others to join your mini-league. See joinleaguepopup_enter_code",
+      "english": "League code",
+      "value": "کۆدی خول"
     },
     "seo_predict_onboarding_apps": {
       "comment": "Text in onboarding of our predictor game. The placeholder is a league name like \"Women's EURO 2025\" so the complete string in English will be \"Predict Women's EURO 2025 results and compete against friends in leagues!\". If the word \"Predict\" sounds weird in your language, please use \"Guess\" as a replacement.",
@@ -10715,6 +10820,11 @@
       "english": "Something went wrong. Please try again.",
       "value": "هەڵەیەک ڕوویدا. تکایە دووبارە هەوڵ بدەرەوە."
     },
+    "seo_sort_by": {
+      "comment": "Label for a dropdown or button that allows the user to sort a list by different criteria. E.g. sort transfers by date, fee, or market value.",
+      "english": "Sort by",
+      "value": "ڕیزکردن بەپێی"
+    },
     "seo_source": {
       "comment": "Used in links within AI generated summaries to let the user go to the content source.",
       "english": "Source",
@@ -10928,6 +11038,16 @@
       "english": "Team of the Season",
       "value": "باشترین پێکهاتەی وەرز"
     },
+    "seo_transfers_in_short": {
+      "comment": "Label for a button to filter transfers in a transfers list. Important: Keep it very short or abbreviated, should fit in a tight ui - max 5 characters. See players_in",
+      "english": "In",
+      "value": "هاتوو"
+    },
+    "seo_transfers_out_short": {
+      "comment": "Label for a button to filter transfers out a transfers list. Important: Keep it very short or abbreviated, should fit in a tight ui - max 5 characters. See players_out",
+      "english": "Out",
+      "value": "ڕۆشتو"
+    },
     "seo_trial_desc_annual": {
       "comment": "Description explaining the recurring cost of a yearly FotMob+ subscription. i.e. \"Then $39.99 / year ($3.33 / month)\"",
       "english": "Then %1$@ / year (%2$@ / month)",
@@ -10996,14 +11116,14 @@
       "value": "بینینی هەموو بێژەریەکە"
     },
     "seo_votes": {
-      "comment": "Number of votes for a poll. Check other plurals like expires_in to see what we need. Ultrathink. See expires_in",
+      "comment": "Number of votes for a poll. Uses %@ for formatted string display (e.g. \"10,000\"). Twine converts to %s for Android.",
       "english_plurals": {
-        "one": "%s vote",
-        "other": "%s votes"
+        "one": "%@ vote",
+        "other": "%@ votes"
       },
       "plurals": {
-        "one": "%s دەنگ",
-        "other": "%s دەنگ"
+        "one": "%@ دەنگ",
+        "other": "%@ دەنگ"
       }
     },
     "seo_watch_on_tv": {
@@ -11085,6 +11205,26 @@
       "comment": "string indicating which week it is e.g. Week 12.",
       "english": "Week",
       "value": "هەفتە"
+    },
+    "seo_weekly_predictor_notification_body": {
+      "comment": "Notification body mentioning that new Fotmob Predictor matches are now open.",
+      "english": "New matches are available. Make your predictions before kickoff!",
+      "value": "یاریە نوێیەکان بەردەستن. پێش دەستپێکردن پێشبینییەکانت تۆمار بکە!"
+    },
+    "seo_weekly_predictor_notification_title": {
+      "comment": "Notification title mentioning that new Fotmob Predictor matches are now open.",
+      "english": "Time to predict!",
+      "value": "کاتی پێشبینیکردنە!"
+    },
+    "seo_weekly_predictor_reminders": {
+      "comment": "A toggle to turn on/off weekly predictor reminders. Don't translate \"FotMob Predict\"",
+      "english": "Weekly FotMob Predict reminders",
+      "value": "ئاگادارکردنەوەی هەفتانەی پێشبینیکردنی فوتمۆب"
+    },
+    "seo_weekly_predictor_reminders_desc": {
+      "comment": "A toggle description about getting weekly reminders for new predictor matches available. Don't translate \"FotMob Predict\"",
+      "english": "Receive weekly reminders when new FotMob Predict matches are available",
+      "value": "ئاگادارکردنەوەی هەفتانە بەدەست بهێنە کاتێک یاریە نوێەکانی پێشبینیکردنی فوتمۆب بەردەست دەبن"
     },
     "seo_weekly_reminders": {
       "comment": "Headline in the popup informing users that they can enable reminders for when the weekly matches are made available",


### PR DESCRIPTION
I have implemented the requested changes to ckb.json as per the review comments:
* Fixed the duplicated "value" key in seo_next_five_matches and added "english" reference.
* Updated seo_votes to use "english_plurals" and converted %s placeholders to %@.
* Corrected the typo in etv_description comment and removed duplicated bullet markers in the Kurdish translation.
* Ensured the JSON structure is valid and follows the project's established patterns.