### PR TITLE
Fix Japanese match event legend translations

### DIFF
--- a/base_languages/ja.json
+++ b/base_languages/ja.json
@@ -6185,7 +6185,7 @@
     "common_var_penalty_goal_retake": {
       "comment": "Penalty goal had to be retaken due to Video Assistant referee. Note that the player scored on the penalty kick in this scenario. We will show a VAR icon besides this label so keep it translated as \"Penalty goal cancelled\" with no reference to Video Assistant referee.",
       "english": "Penalty goal - to be retaken",
-      "value": "ペナルティゴール - やり直し"
+      "value": "PKゴール - やり直し"
     },
     "common_var_penalty_miss_retake": {
       "comment": "Penalty miss had to be retaken due to Video Assistant referee. Note that the player missed the penalty kick in this scenario. We will show a VAR icon besides this label so keep it translated as \"Penalty miss cancelled\" with no reference to Video Assistant referee.",

--- a/base_languages/ja.json
+++ b/base_languages/ja.json
@@ -6190,7 +6190,7 @@
     "common_var_penalty_miss_retake": {
       "comment": "Penalty miss had to be retaken due to Video Assistant referee. Note that the player missed the penalty kick in this scenario. We will show a VAR icon besides this label so keep it translated as \"Penalty miss cancelled\" with no reference to Video Assistant referee.",
       "english": "Missed penalty - to be retaken",
-      "value": "ペナルティを外しました - やり直し"
+      "value": "PK失敗 - やり直し"
     },
     "common_var_pending": {
       "comment": "Information that the Video Assistant Referee is checking something",
@@ -8748,7 +8748,7 @@
     "notifications_player_substitution": {
       "comment": "User can enable alerts when a player is substituted (in our out or the pitch). This is the label on the checkbox that the user can toggle to enable those alerts.",
       "english": "Substitution",
-      "value": "控え"
+      "value": "交代"
     },
     "notifications_player_throws": {
       "comment": "Goalkeeper throws or throw-ins from the side. We use the same translation for both.",

--- a/base_languages/ja.json
+++ b/base_languages/ja.json
@@ -4450,7 +4450,7 @@
     },
     "common_missed_penalty": {
       "english": "Missed penalty",
-      "value": "ペナルティを外しました"
+      "value": "PK失敗"
     },
     "common_more": {
       "comment": "Last tab on the main screen, which contains settings, TV guide, etc.",
@@ -5296,7 +5296,7 @@
     "common_saved_penalties": {
       "comment": "Label for number of penalties a keeper has saved in a match",
       "english": "Saved penalties",
-      "value": "PKセーブ数"
+      "value": "PKセーブ"
     },
     "common_saves_inside_box": {
       "comment": "Keeper saves the ball from a shot that occured inside the penalty box",
@@ -5345,7 +5345,7 @@
     "common_second_yellow_card": {
       "comment": "A label explaining an icon showing a yellow and a red card on top of each other indicating that the player got a red card from two yellow cards. So he got his Second yellow.",
       "english": "Second yellow",
-      "value": "2枚目のイエロー"
+      "value": "イエロー2枚"
     },
     "common_secondary_onboarding_teams_body": {
       "comment": "Explanation to the user why he should add more favorite teams and players. @",
@@ -5650,7 +5650,7 @@
     },
     "common_subs": {
       "english": "Substitutes",
-      "value": "控え"
+      "value": "交代"
     },
     "common_subs_stats": {
       "english": "Substitutes",
@@ -7889,7 +7889,7 @@
     },
     "notifications_injured": {
       "english": "Injured",
-      "value": "負傷中"
+      "value": "負傷"
     },
     "notifications_injured_and_suspended_players": {
       "english": "Injured and suspended players",
@@ -8181,7 +8181,7 @@
     },
     "notifications_injury_6": {
       "english": "Injured",
-      "value": "負傷中"
+      "value": "負傷"
     },
     "notifications_injury_61": {
       "english": "Eye injury",


### PR DESCRIPTION
## Summary
- Fixes Japanese translation issues for match event legend/timeline icons as reported in #40
- Corrects grammatical inconsistencies (mixing verbs/nouns), contextual errors, and overly long phrasing for mobile UI
- Aligns related VAR and notification keys for terminology consistency

## Changes

| Key | Before | After | Rationale |
|-----|--------|-------|-----------|
| `common_missed_penalty` | ペナルティを外しました | PK失敗 | Noun form, standard football term, 11→4 chars |
| `common_saved_penalties` | PKセーブ数 | PKセーブ | Remove redundant 数 (number) suffix |
| `common_subs` | 控え | 交代 | "Bench player" → "Substitution" (matches the action icon) |
| `common_second_yellow_card` | 2枚目のイエロー | イエロー2枚 | More concise, same meaning |
| `notifications_injured` | 負傷中 | 負傷 | Event noun, not continuous state |
| `notifications_injury_6` | 負傷中 | 負傷 | Same as above |
| `common_var_penalty_miss_retake` | ペナルティを外しました - やり直し | PK失敗 - やり直し | Consistency with common_missed_penalty |
| `notifications_player_substitution` | 控え | 交代 | English key is "Substitution", not "Bench" |
| `common_var_penalty_goal_retake` | ペナルティゴール - やり直し | PKゴール - やり直し | Align with adjacent PK terminology |

Closes #40

## Test plan
- [ ] Verify match event legend displays correctly with new shorter strings
- [ ] Check substitution icon label reads naturally as an action
- [ ] Confirm no text overflow on smaller screens with updated strings
- [ ] Check VAR penalty labels show consistent PK terminology

🤖 Generated with [Claude Code](https://claude.com/claude-code)