### PR TITLE
New Strings Translated

### DIFF
--- a/base_languages/ckb.json
+++ b/base_languages/ckb.json
@@ -2707,7 +2707,7 @@
       "value": "هێرشبەر"
     },
     "common_audio_pause": {
-      "comment": "Generic pause button label for audio playback controls (not match half-time).",
+      "comment": "Generic pause button label for audio playback controls (not the half-time break in a football match).",
       "english": "Pause",
       "value": "وەستاندن"
     },
@@ -3041,7 +3041,7 @@
     "common_complete_lineup": {
       "comment": "A toast indicating that the user has to complete the lineup in order to save or share",
       "english": "Complete lineup",
-      "value": "لاینەپەکە تەواو بکە"
+      "value": "پێکهاتەکە تەواو بکە"
     },
     "common_concacaf_championsleague": {
       "comment": "Label indicating that the teams get a place in CONCACAF Champions League.",
@@ -3101,7 +3101,7 @@
     "common_could_not_delete_saved_lineup": {
       "comment": "A toast indicating that we were not able to delete the users saved lineup",
       "english": "Could not delete saved lineup",
-      "value": "نەیتوانرا ڕیزبەندی پاشەکەوتکراو بسڕینەوە"
+      "value": "نەتوانرا پێکهاتە پاشەکەوتکراوەکە بسڕدرێتەوە"
     },
     "common_countries": {
       "comment": "Header in the onboarding for the WC2018 teams (to pick the national teams to follow)",
@@ -3169,7 +3169,7 @@
     "common_delete_saved_lineup": {
       "comment": "An alert action asking the user if he wants to delete his saved lineup",
       "english": "Delete saved lineup?",
-      "value": "ئایا دەتەوێت ڕیزکردنی هەڵگیراو بسڕیتەوە؟"
+      "value": "پێکهاتە پاشەکەوتکراوەکە دەسڕیتەوە؟"
     },
     "common_deselect": {
       "english": "Deselect",
@@ -3693,7 +3693,7 @@
     "common_free_formation": {
       "comment": "Indicates a free formation in the lineup builder where the user can move positions as they want",
       "english": "Free formation",
-      "value": "ڕیزبەندی ئازاد"
+      "value": "شێوازی ئازاد"
     },
     "common_free_kick": {
       "comment": "Type of goal via a free kick",
@@ -4136,7 +4136,7 @@
     "common_last_lineup_unavailable": {
       "comment": "A toast message indicating that the last lineup is unavailable for the selected team. Add no placeholder after the \"for\".\"",
       "english": "Last lineup unavailable for",
-      "value": "ڕیزەی یاریزانانی دواخەر بەردەست نییە بۆ"
+      "value": "دوایین پێکهاتە بەردەست نییە بۆ"
     },
     "common_last_man_tackle": {
       "comment": "Keeper or defender tackles an attacker that is through on goal",
@@ -4279,12 +4279,12 @@
     "common_lineup_builder_more_desc": {
       "comment": "The fotmob lineup builder feature description in the more tab",
       "english": "Build your own FotMob lineup",
-      "value": "یانزەکەی تایبەتی FotMob دروست بکە"
+      "value": "پێکهاتەی تایبەت بە خۆت لە فوتمۆب دروست بکە"
     },
     "common_lineup_builder_onboarding_desc": {
       "comment": "An onboarding description for what the lineup builder is about. Keep it brief.",
       "english": "Build your dream XI, pick your team's next lineup, or plan your transfer window.",
-      "value": "یانزەی خەونیت دروست بکە، یان یانزەی داهاتووی تیمەکەت هەڵبژێرە، یان پەنجەرەی گواستنەوەکان پلاندانان بکە."
+      "value": "پێکهاتەی خەونەکانت دابنێ، پێکهاتەی داهاتووی یانەکەت هەڵبژێرە، یان پلانی گواستنەوەکان دابنێ."
     },
     "common_loading": {
       "english": "Loading...",
@@ -4496,7 +4496,7 @@
     "common_my_lineups": {
       "comment": "A menu action label for the users saved lineups in lineup builder",
       "english": "My lineups",
-      "value": "لاین‌ئەپەکانم"
+      "value": "پێکهاتەکانم"
     },
     "common_my_matches": {
       "english": "My matches",
@@ -4513,7 +4513,7 @@
     "common_name_your_lineup": {
       "comment": "A label indicating that you can name your lineup",
       "english": "Name your lineup",
-      "value": "ناوی ڕیزبەندیت دابنێ"
+      "value": "ناوێک بۆ پێکهاتەکەت دابنێ"
     },
     "common_network_connection_issues_notification_ios": {
       "english": "It looks like we have problems fetching new data. %@",
@@ -4535,7 +4535,7 @@
     "common_new_lineup": {
       "comment": "A menu action allowing the user to create a new lineup",
       "english": "New lineup",
-      "value": "ترکیبی نوێ"
+      "value": "پێکهاتەی نوێ"
     },
     "common_new_to_fotmob": {
       "english": "I'm new to FotMob!",
@@ -4584,7 +4584,7 @@
     "common_no_lineups_saved": {
       "comment": "A placeholder text indicating the user has no saved lineups",
       "english": "No lineups saved",
-      "value": "هیچ پێکهاتەیەکی هەڵگیراو نییە"
+      "value": "هیچ پێکهاتەیەک پاشەکەوت نەکراوە"
     },
     "common_no_match_facts_available": {
       "english": "No match facts available",
@@ -5319,12 +5319,12 @@
     "common_save_action": {
       "comment": "A menu action for saving lineups",
       "english": "Save",
-      "value": "هەڵگرتن"
+      "value": "پاشەکەوتکردن"
     },
     "common_saved_lineup_deleted": {
       "comment": "A toast indicating that we successfully deleted the users saved lineup",
       "english": "Saved lineup deleted",
-      "value": "ترکیبی هەڵگیراو سڕایەوە"
+      "value": "پێکهاتە پاشەکەوتکراوەکە سڕدرایەوە"
     },
     "common_saved_penalties": {
       "comment": "Label for number of penalties a keeper has saved in a match",
@@ -5811,7 +5811,7 @@
     "common_team_pre_fill": {
       "comment": "A label indicating that you can prefill a team in our lineup builder, keep it brief.",
       "english": "Team pre-fill",
-      "value": "پڕکردنەوەی پێشوەختی تیم"
+      "value": "پڕکردنەوەی پێشوەختەی تیم"
     },
     "common_team_selection_intent_confirmation": {
       "comment": "Keep ‘${team}’-part not-translated. Siri-intent confirmation for the team selection in widgets",
@@ -5893,7 +5893,7 @@
     "common_this_removes": {
       "comment": "An alert action description indicating that the action removes a lineup. Add no placeholder after the \"removes\"",
       "english": "This removes",
-      "value": "ئەمە دەسڕێتەوە"
+      "value": "ئەمە دەبێتە هۆی سڕینەوەی"
     },
     "common_three_match_series": {
       "comment": "Header for popup for aggregated play-off matches",
@@ -6185,7 +6185,7 @@
     "common_untitled": {
       "comment": "a fallback name if the user has not specified a name for their lineup in lineup builder",
       "english": "Untitled",
-      "value": "بەبێ ناونیشان"
+      "value": "بێ ناو"
     },
     "common_upcoming_matches": {
       "english": "Upcoming matches",
@@ -7425,6 +7425,11 @@
       "english": "Azerbaijan",
       "value": "ئازەربایجان"
     },
+    "notifications_bangladesh": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "Bangladesh",
+      "value": "بەنگلادش"
+    },
     "notifications_belarus": {
       "english": "Belarus",
       "value": "بێلاڕووس"
@@ -7520,6 +7525,11 @@
       "comment": "Heading for notification/alert settings",
       "english": "Manage all your active news, team, player and league notifications",
       "value": "بەڕێوەبردنی ئاگادارکەرەوەکانی هەواڵ، یانە، یاریزان و خولەکان"
+    },
+    "notifications_china": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "China",
+      "value": "چین"
     },
     "notifications_clearances": {
       "comment": "A defensive clearance – where a player under pressure kicks the ball clear of the defensive zone or/and out of play",
@@ -7818,6 +7828,11 @@
       "english": "Germany",
       "value": "ئەڵمانیا"
     },
+    "notifications_ghana": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "Ghana",
+      "value": "غانا"
+    },
     "notifications_goal_v2": {
       "english": "Goal",
       "value": "گۆۆڵ"
@@ -7870,6 +7885,11 @@
       "comment": "support screen headline (\\n for line break)",
       "english": "Hello,\\nhow can we help you?",
       "value": "سڵاو،\\nچۆن دەتوانین یارمەتیت بدەین؟"
+    },
+    "notifications_hong_kong": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "Hong Kong",
+      "value": "هۆنگ کۆنگ"
     },
     "notifications_how_about_rating": {
       "comment": "Used for rating dialog, button label so keep it short",
@@ -8363,6 +8383,11 @@
       "english": "Italy",
       "value": "ئیتاڵیا"
     },
+    "notifications_japan": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "Japan",
+      "value": "ژاپۆن"
+    },
     "notifications_kazakhstan": {
       "english": "Kazakhstan",
       "value": "کازاخستان"
@@ -8422,6 +8447,16 @@
       "comment": "The republic of North Macedonia.",
       "english": "North Macedonia",
       "value": "مەقدۆنیای باکوور"
+    },
+    "notifications_malaysia": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "Malaysia",
+      "value": "مالیزیا"
+    },
+    "notifications_malta": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "Malta",
+      "value": "ماڵتا"
     },
     "notifications_match_date": {
       "english": "Match date",
@@ -8484,6 +8519,11 @@
       "comment": "Abbrevation of minutes",
       "english": "Min",
       "value": "خولەک"
+    },
+    "notifications_morocco": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "Morocco",
+      "value": "مەغریب"
     },
     "notifications_my_leagues": {
       "comment": "Profile page list header",
@@ -8557,9 +8597,19 @@
       "english": "Writing results to log file",
       "value": "نووسینی ئەنجامەکان بۆ فایلی تۆمار"
     },
+    "notifications_new_zealand": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "New Zealand",
+      "value": "نیوزلەندا"
+    }, 
     "notifications_nice_are_you_all_set_or_do_you_want_to_add_transfer_news_league_wide_transfer_alerts_and_more": {
       "english": "Nice! Are you all set or do you want to add league-wide transfer alerts or customize the team transfers?",
       "value": "ناوازەیە! ئایا هەموو شتێک ئامادەیە یان دەتەوێت ئاگادارکەرەوەی گواستنەوەکان بۆ هەموو خولەکە یان یانەی دیاریکراو زیاد بکەیت؟"
+    },
+    "notifications_nigeria": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "Nigeria",
+      "value": "نەیجیریا"
     },
     "notifications_night_mode": {
       "comment": "Deprecated",
@@ -8644,6 +8694,11 @@
       "english": "Open on watch",
       "value": "کردنەوە لەسەر کاتژمێر"
     },
+    "notifications_pakistan": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "Pakistan",
+      "value": "پاکستان"
+    },
     "notifications_pass_percentage": {
       "english": "Pass success",
       "value": "پاسی سەرکەوتوو"
@@ -8660,6 +8715,11 @@
     "notifications_penalties_won": {
       "english": "Penalties won",
       "value": "بەدەستهێنانی لێدانی سزا"
+    },
+    "notifications_philippines": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "Philippines",
+      "value": "فلیپین"
     },
     "notifications_pin_to_homescreen": {
       "comment": "Option for adding a shortcut to the team to the homescreen",
@@ -9005,9 +9065,19 @@
       "english": "Signing in…",
       "value": "چوونە ناوەوە…"
     },
+    "notifications_singapore": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "Singapore",
+      "value": "سەنگافورە"
+    },
     "notifications_slovakia": {
       "english": "Slovakia",
       "value": "سلۆڤاکیا"
+    },
+    "notifications_slovenia": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "Slovenia",
+      "value": "سلۆڤینیا"
     },
     "notifications_social_media_updates": {
       "comment": "A user can choose to get alerts for Twitter & Instagram updates for a player",
@@ -9027,6 +9097,11 @@
     "notifications_south_africa": {
       "english": "South Africa",
       "value": "ئەفریقای باشوور"
+    },
+    "notifications_south_korea": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "South Korea",
+      "value": "کۆریای باشوور"
     },
     "notifications_spain": {
       "comment": "Used in TV schedules filter",
@@ -9083,6 +9158,11 @@
     "notifications_tackles_succeeded": {
       "english": "Tackles won",
       "value": "لێسەندنەوەی سەرکەوتوو"
+    },
+    "notifications_tanzania": {
+      "comment": "Country name used in tv guide page on web",
+      "english": "Tanzania",
+      "value": "تەنزانیا"
     },
     "notifications_team_play": {
       "english": "Team play",
@@ -9386,12 +9466,12 @@
     "seo_allow_notifications": {
       "comment": "Call to action text to prompt for remote notifications",
       "english": "Allow notifications",
-      "value": "ڕێگە بدە بە ئاگادارکردنەوەکان"
+      "value": "ڕێگەدان بە ئاگادارکردنەوەکان"
     },
     "seo_allow_notifications_to_get_match_updates": {
       "comment": "Description for \"prompt for notifications\" step in onboarding to further explain what kind of notifications the user will get if they enable them.",
       "english": "Allow notifications to get match updates, which can be customized later.",
-      "value": "ڕێگە بە ئاگادارکردنەوەکان بدە بۆ وەرگرتنی نوێکارییەکانی یاری؛ دەتوانیت دواتر ڕێکخستنەکانیان بگۆڕیت."
+      "value": "ڕێگە بدە بە ئاگادارکردنەوەکان بۆ وەرگرتنی نوێکارییەکانی یاری، کە دەتوانیت دواتر دەستکارییان بکەیت."
     },
     "seo_android_billing_disclaimer": {
       "comment": "A legal disclaimer for in app subscription in the app for Google Play",
@@ -9619,7 +9699,7 @@
     "seo_expected_goals_set_play_conceded": {
       "comment": "Label for a statistic showing the expected goals (xG) conceded from set pieces - free kicks, corners, throw ins, etc. (not penalties) in a football match. See set_piece_goals",
       "english": "xG set play conceded",
-      "value": "xG لەدەستدراو لە دۆخی توپە وەستاوەکان"
+      "value": "xG یانەی بەرامبەر بە تۆپی جێگیر"
     },
     "seo_expected_return_date_about_1_2_weeks": {
       "comment": "A text describing for how long a player is out injured or absent.",
@@ -9709,7 +9789,7 @@
     "seo_follow_players_to_track_performances": {
       "comment": "Sub-header for player step in onboarding to indicate what following a player actually means.",
       "english": "Follow players to track performances and transfers.",
-      "value": "یاریزان بەدوادا بکە بۆ ئەوەی چاودێری ئاستی یاری و گواستنەوەکان بکەیت."
+      "value": "بەدواداچوون بۆ یاریزانان بکە بۆ چاودێریکردنی ئاست و گواستنەوەکانیان."
     },
     "seo_followed_leagues": {
       "comment": "Header for the list of leagues you are following.",
@@ -10169,7 +10249,7 @@
     "seo_never_miss_a_goal": {
       "comment": "Title for \"prompt for notifications\" step in onboarding to explain why users should enable notifications.",
       "english": "Never miss a goal",
-      "value": "ھیچ گۆڵێک لەدەست مەدە"
+      "value": "هیچ گۆڵێک لەدەست مەدە"
     },
     "seo_newsletter": {
       "comment": "A header indicating you can sign up for a newsletter where we send emails to the user about football things.",
@@ -10631,7 +10711,7 @@
     "seo_search_leagues_placeholder": {
       "comment": "Placeholder for search text field.",
       "english": "Search leagues",
-      "value": "گەڕان بەدوای لیگەکان"
+      "value": "گەڕان بۆ خولەکان"
     },
     "seo_search_players_placeholder": {
       "comment": "Placeholder for search text field.",
@@ -10641,7 +10721,7 @@
     "seo_search_teams_placeholder": {
       "comment": "Placeholder for search text field.",
       "english": "Search teams",
-      "value": "گەڕان بەدوای تیمەکان"
+      "value": "گەڕان بۆ یانەکان"
     },
     "seo_season_total": {
       "comment": "Text in a dropdown showing the season total score of a prediction competition, if the text is longer in the translated language use a shorter natural phrase like \"total\" instead.",
@@ -10666,12 +10746,12 @@
     "seo_set_piece_goals": {
       "comment": "Label for a statistic showing the number of goals scored from set pieces - free kicks, corners, throw ins, etc. (not penalties) in a football match. See expected_goals_set_play",
       "english": "Set piece goals",
-      "value": "گۆڵەکانی دۆخی ڕاوەستان"
+      "value": "گۆڵ بە تۆپی جێگیر"
     },
     "seo_set_piece_goals_conceded": {
       "comment": "Label for a statistic showing the number of goals conceded from set pieces - free kicks, corners, throw ins, etc. (not penalties) in a football match. See set_piece_goals",
       "english": "Set piece goals conceded",
-      "value": "گۆڵە خوراوەکان لە حاڵەتە ستانداردەکانەوە"
+      "value": "گۆڵ لێکران بە تۆپی جێگیر"
     },
     "seo_share_link": {
       "comment": "Text for the button that opens the share dialogue for the league invite link.",
@@ -10731,32 +10811,32 @@
     "seo_site_description_league_matches": {
       "comment": "SEO description for league matches page showing results and fixtures with live scores. First %@ is the league name, second %@ is the season",
       "english": "All %1$@ match results and upcoming fixtures for %2$@. Sort by date, round, club or group. Live scores and results updated every matchday.",
-      "value": "هەموو ئەنجامەکانی یارییەکانی %1$@ و یارییە داهاتووەکان بۆ %2$@. ڕیزکردن بە پێی بەروار، ڕۆند، یانە یان گرووپ. سکۆری ڕاستەوخۆ و ئەنجامەکان لە هەر ڕۆژی یارییەکاندا نوێ دەکرێنەوە."
+      "value": "ئەنجامی هەموو یارییەکان و خشتەی یارییەکانی داهاتووی %1$@ بۆ وەرزی %2$@. بەپێی بەروار، گەڕ، یانە یان کۆمەڵە ڕێک بخە. ئەنجامە ڕاستەوخۆکان لە هەموو ڕۆژێکی یارییەکاندا نوێ دەکرێنەوە."
     },
     "seo_site_description_league_news": {
       "comment": "SEO description for league news page showing latest news, transfers, injuries and match updates. %@ is the league name",
       "english": "Stay up to date with the latest %@ news including transfer rumours, injury updates, match highlights, match previews and managerial changes.",
-      "value": "لەگەڵ نوێترین هەواڵی %@ بەڕۆژ بمەوە، وەک شایعاتی گواستنەوە، نوێکارییەکانی برین، هایلایتەکانی یاری، پێشبینی یاری و گۆڕانی ڕاهێنەر."
+      "value": "ئاگاداری نوێترین هەواڵەکانی %1$@ بە، لەوانە دەنگۆکانی گواستنەوە، زانیاری پێکانەکان، کورتەی یارییەکان، پێشبینی یارییەکان و گۆڕانکاریەکانی ڕاهێنەران."
     },
     "seo_site_description_league_overview": {
       "comment": "SEO description for league overview page showing table, results, fixtures and top scorers. First %@ is the league name, second %@ is the season",
       "english": "%1$@ overview for %2$@ with league table, latest results, upcoming fixtures, top scorers and the latest news from around the league.",
-      "value": "پوختەی %1$@ بۆ %2$@ لەگەڵ خشتەی لیگ، دوایین ئەنجامەکان، یارییەکانی داهاتوو، سەرەوە گۆڵزانەکان و دوایین هەواڵەکان لە هەموو لیگەکەوە."
+      "value": "کورتەی %1$@ بۆ وەرزی %2$@، لەگەڵ ڕیزبەندی خول، نوێترین ئەنجامەکان، خشتەی یارییەکانی داهاتوو، گۆڵکاران و نوێترین هەواڵەکانی ناو خولەکە."
     },
     "seo_site_description_league_playoff": {
       "comment": "SEO description for league playoff/knockout page showing bracket, fixtures and results. First %@ is the league name, second %@ is the season",
       "english": "%1$@ playoff bracket for %2$@ with knockout fixtures, results, matchups and the road to the final. Follow every round of the tournament live.",
-      "value": "خشتەی پلیئۆفی %1$@ بۆ %2$@، لەگەڵ یاریە سڕاوەکان، ئەنجامەکان، جووتی یاری و ڕێگای بۆ فیناڵ. هەموو قۆناغەکانی تۆرنەمێنتەکە بە ڕاستەوخۆ شوێن بکە."
+      "value": "خشتەی یارییەکانی پاشکۆی %1$@ بۆ وەرزی %2$@، لەگەڵ یارییەکانی قۆناغی کرانە دەرەوە، ئەنجامەکان، ڕووبەڕووبوونەوەکان و ڕێگای گەیشتن بە یاری کۆتایی. ڕاستەوخۆ چاودێری هەموو گەڕەکانی پاڵەوانێتییەکە بکە."
     },
     "seo_site_description_league_stats": {
       "comment": "SEO description for league stats page showing top scorers, assists, ratings and performance data. First %@ is the league name, second %@ is the season",
       "english": "%1$@ statistics for %2$@ with top scorers, assist leaders, player ratings, clean sheets and detailed performance data for every team.",
-      "value": "ئاماری %1$@ بۆ %2$@ لەگەڵ باشترین گۆڵهێنەرەکان، پێشەنگانی یارمەتی، هەڵسەنگاندنی یاریزانان، کلین شیت و زانیاریی وردی کارایی بۆ هەر تیمێک."
+      "value": "ئامارەکانی %1$@ بۆ وەرزی %2$@، لەگەڵ لیستی گۆڵکاران، ئەسیستکاران، هەڵسەنگاندنی یاریزانان، کلین شیت و داتا وردەکانی ئاستی هەموو یانەکان."
     },
     "seo_site_description_league_table": {
       "comment": "SEO description for league table page showing standings with points, form and upcoming opponents. First %@ is the league name, second %@ is the season",
       "english": "%1$@ standings for %2$@ with current form, home and away records, goal difference and upcoming opponents for every team.",
-      "value": "خشتەی ڕیزبەندی %1$@ بۆ %2$@ لەگەڵ فۆرمی ئێستا، تۆماری یارییەکانی ماڵەوە و دەرەوە، جیاوازی گۆڵ و ڕکابەرە داهاتووەکان بۆ هەر تیمێک."
+      "value": "ڕیزبەندی %1$@ بۆ وەرزی %2$@، لەگەڵ ئاستی ئێستا، تۆماری یارییەکانی ناو یاریگا و دەرەوەی یاریگا، جیاوازی گۆڵ و ڕکابەرەکانی داهاتووی هەموو یانەکان."
     },
     "seo_site_description_league_table_xg": {
       "comment": "Meta description for the page with the xG table for the given league. With the league name as %1$@, and year indicator as %2$@.",
@@ -10766,12 +10846,12 @@
     "seo_site_description_league_transfers": {
       "comment": "SEO description for league transfers page showing all transfers, fees and contract details. %@ is the league name",
       "english": "Complete %@ transfer overview with all incoming and outgoing players, transfer fees, contract details and loan moves across every club.",
-      "value": "تێڕوانینی تەواوی گواستنەوەکانی %@ بە هەموو یاریزانە هاتووەکان و ڕۆشتووان، کرێی گواستنەوە، وردەکاری گرێبەست و گواستنەوەکانی قەرز لە سەرانسەری هەموو یانەکاندا."
+      "value": "کورتەی تەواوی گواستنەوەکانی %1$@ لەگەڵ هەموو یاریزانە هاتوو و ڕۆیشتووەکان، تێچووی گواستنەوە، وردەکاری گرێبەستەکان و گواستنەوەکانی بە خواستن لە سەرجەم یانەکاندا."
     },
     "seo_site_description_league_trophies": {
       "comment": "SEO description for league trophies page showing historical winners, runner-up and title races. %@ is the league name",
       "english": "Explore the full %@ history with past champions, runners-up, title races and season-by-season results going back through the decades.",
-      "value": "مێژووی تەواوی %@ بگەڕێوە؛ پاڵەوانانی پێشو، نایب‌پاڵەوانان، پێشبڕکێی ناونیشان و ئەنجامەکانی وەرز بە وەرز تا دەهەکانەوە."
+      "value": "گەڕان بەناو مێژووی تەواوی %1$@دا، لەگەڵ پاڵەوانەکانی پێشوو، پلەی دووەمەکان، ململانێی نازناوەکان و ئەنجامەکانی وەرز بە وەرزی چەندین دەیەی ڕابردوو."
     },
     "seo_site_description_match": {
       "comment": "This is overall description on a match page before the match starts. To be shown in search results on the web etc",
@@ -10781,7 +10861,7 @@
     "seo_site_description_match_with_alias": {
       "comment": "This is a copy of site_description_match, but with the derby name as alias. E.g. \"Él Clásico: Real Madrid vs Barcelona on ...\". See site_description_match.",
       "english": "%4$@: %1$@ vs %2$@ on %3$@. Check live results, H2H, match stats, lineups, player ratings, insights, team forms, shotmap, and highlights.",
-      "value": "%4$@: یانەی %1$@ دژی %2$@ لە %3$@. ئەنجامە ڕاستەوخۆکان، H2H، ئاماری یاری، پێکهاتە، هەڵسەنگاندنی یاریزانان، تێڕوانینەکان، فۆرمی تیمەکان، نەخشەی شوت و هایلایتەکان ببینە."
+      "value": "​یاری %4$@: %1$@ دژی %2$@ لە %3$@. سەیری ئەنجامە ڕاستەوخۆکان، مێژووی ڕووبەڕوبونەوەکان، ئامارەکانی یاری، پێکهاتەکان، هەڵسەنگاندنی یاریزانان، شیکارییەکان، ئاستی یانەکان، نەخشەی شووتەکان و کورتەی یارییەکە بکە."
     },
     "seo_site_description_stats_league": {
       "comment": "Page description for page showing teams or players in a league, sorted by a single stat. With stat, leaguename and seasonname as input. Eg \"Assists - LaLiga 2023/2024 stats\"",
@@ -10796,42 +10876,42 @@
     "seo_site_description_team_fixtures": {
       "comment": "SEO description for team fixtures page showing fixture list with live scores and results. %@ is the team name",
       "english": "Full %@ fixture list with live scores, results and upcoming matches across all competitions including league and cup games.",
-      "value": "لیستی تەواوی یارییەکانی %@ لەگەڵ سکۆری ڕاستەوخۆ، ئەنجامەکان و یارییە داهاتووەکان لە هەموو پێشبڕکێکاندا، بە ئەژمارکردنی یارییەکانی لیگ و جام."
+      "value": "خشتەی تەواوی یارییەکانی %1$@ لەگەڵ ئەنجامە ڕاستەوخۆکان و یارییەکانی داهاتوو لە سەرجەم پاڵەوانێتییەکاندا، لەوانە یارییەکانی خول و جام."
     },
     "seo_site_description_team_history": {
       "comment": "SEO description for team history page showing past league finishes, results, trophies and coaches. %@ is the team name",
       "english": "Explore %@ history with past league finishes, season-by-season results, trophy cabinet, coach history and win percentage.",
-      "value": "مێژووی %@ بکۆڵەرەوە: پلەکانی پێشووی لیگ، ئەنجامەکانی وەرز بە وەرز، تروفی‌کابینەت، مێژووی ڕاهێنەران و ڕێژەی برد."
+      "value": "گەڕان بەناو مێژووی %1$@دا، لەگەڵ ڕیزبەندیەکانی پێشووی خول، ئەنجامەکانی وەرز بە وەرز، مۆزەخانەی نازناوەکان، مێژووی ڕاهێنەران و ڕێژەی سەرکەوتنەکان."
     },
     "seo_site_description_team_news": {
       "comment": "SEO description for team news page showing latest news, transfer rumours and match updates. %@ is the team name",
       "english": "Stay up to date with all the latest %@ news including transfer rumours, injury updates, match previews and post-match analysis.",
-      "value": "لەگەڵ هەموو نوێترین هەواڵەکانی %@ بەڕۆژبە؛ لەوانەش قسەوباسەکانی گواستنەوە، نوێکردنەوەی دۆخی برین، پێشبینینی یاری و شیکردنەوەی دوای یاری."
+      "value": "ئاگاداری نوێترین هەواڵەکانی %1$@ بە، لەوانە دەنگۆکانی گواستنەوە، زانیاری پێکانەکان، پێشبینی یارییەکان و شیکارییەکانی دوای یاری."
     },
     "seo_site_description_team_overview": {
       "comment": "SEO description for team overview page showing results, fixtures, standings and news. %@ is the team name",
       "english": "Get the latest %@ results, upcoming fixtures, league standings, top player stats and team news. Updated live throughout the season.",
-      "value": "دوایین ئەنجامەکانی %@، یارییەکانی داهاتوو، خشتەی لیگ، باشترین ئاماری یاریزانان و هەواڵی تیم وەربگرە. بە شێوەی ڕاستەوخۆ لە ماوەی هەموو وەرزەکەدا نوێ دەکرێتەوە."
+      "value": "نوێترین ئەنجامەکانی %1$@، خشتەی یارییەکانی داهاتوو، ڕیزبەندی خول، ئاماری باشترین یاریزانان و هەواڵەکانی یانەکە بەدەست بهێنە. لە تەواوی وەرزەکەدا بە شێوەی ڕاستەوخۆ نوێ دەکرێتەوە."
     },
     "seo_site_description_team_squad": {
       "comment": "SEO description for team squad page showing player details, positions, injuries and coaching staff. %@ is the team name",
       "english": "View the full %@ squad with player positions, shirt numbers, ages, nationalities, injury updates and most valuable players.",
-      "value": "تەواوی کادری %@ ببینە، لەگەڵ پۆستی یاریزانان، ژمارەی جل، تەمەن، نەتەوە، نوێکارییەکانی برین و گرانبەهاترین یاریزانان."
+      "value": "بینەری پێکهاتەی تەواوی %1$@ بن، لەگەڵ شوێنی یاریزانان، ژمارەی درێسەکان، تەمەن، نەتەوەکان، زانیاری پێکانەکان و گرانترین یاریزانان."
     },
     "seo_site_description_team_stats": {
       "comment": "SEO description for team stats page showing detailed player and team statistics. %@ is the team name",
       "english": "Detailed %@ player and team statistics including ratings, goals, assists, clean sheets, shots on target and season performance.",
-      "value": "ئاماری وردی یاریزان و تیمی %@، لەگەڵ هەڵسەنگاندنەکان، گۆڵ، پاس گۆڵ، کلین‌شیت، شوتی لەچوارچێوە و کارکردی وەرز."
+      "value": "ئامارە وردەکانی یاریزانان و یانەی %1$@، لەگەڵ هەڵسەنگاندنەکان، گۆڵەکان،ئەسیستەکان، کلین شیت، لێدانەکانی ناو گۆڵ و ئاستی وەرزەکە."
     },
     "seo_site_description_team_table": {
       "comment": "SEO description for team table page showing league and cup standings with form and upcoming opponents. %@ is the team name",
       "english": "See where %@ stand in the league and cup tables with points, form guide, goal difference and upcoming opponents.",
-      "value": "سەیر بکە %@ لە خشتەکانی لیگ و کاپ چ شوێنێکدا دەوەستێت، لەگەڵ خاڵ، فۆرم، جیاوازی گۆڵ و یارییەکانی داهاتوو."
+      "value": "ببینە %1$@ لە چ پلەیەکی خشتەی خول و جامەکاندایە، لەگەڵ خاڵەکان، ڕێبەری ئاست، جیاوازی گۆڵ و ڕکابەرەکانی داهاتوو."
     },
     "seo_site_description_team_transfers": {
       "comment": "SEO description for team transfers page showing complete transfer history. %@ is the team name",
       "english": "Complete %@ transfer history with players in, players out, loan deals, contract extensions, transfer fees and destinations.",
-      "value": "مێژووی تەواوی گواستنەوەکانی %@، لەگەڵ یاریزانە هاتووەکان و ڕۆشتووەکان، دەنەوەکان (عاریه)، درێژکردنەوەی گرێبەست، کرێی گواستنەوە و شوێنەکان."
+      "value": "مێژووی تەواوی گواستنەوەکانی %1$@ لەگەڵ یاریزانە هاتوو و ڕۆیشتووەکان، گرێبەستە بە خواستنەکان، درێژکردنەوەی گرێبەست، تێچووی گواستنەوە و ئەو یانەیەی کە بۆی چووە."
     },
     "seo_site_description_transfer_center": {
       "comment": "Meta description tag value for the transfer center page",
@@ -10846,12 +10926,12 @@
     "seo_site_description_tv_guide": {
       "comment": "SEO description for tv schedule page of football matches filtered by country. %@ is the country name. see [site_title_tv_guide]",
       "english": "Find football matches live on TV in %@ today and this week. TV schedules with kick-off times for Premier League, Champions League, World Cup and more.",
-      "value": "یارییەکانی تۆپی پێ لەسەر زیندە لە تەلەفیزیۆن لە %@ ئەمڕۆ و ئەم هەفتە بدۆزەرەوە. خشتەی پەخشکردنی تەلەفیزیۆن بە کاتی دەستپێکی یاری بۆ پریمیرلیگ، چامپیۆنزلیگ، جامی جیهان و زیاتر."
+      "value": "خشتەی یارییەکانی تۆپی پێ کە ئەمڕۆ و ئەم هەفتەیە لە تەلەفزیۆنەکانی %1$@ بە ڕاستەوخۆ پەخش دەکرێن. کاتەکانی دەسپێکردنی یارییەکان لە خولی نایابی ئینگلیزی، چامپیۆنز لیگ، مۆندیال و چەندینی تر."
     },
     "seo_site_description_tv_guide_channel": {
       "comment": "SEO description for tv schedule page filtered by channel name. %@ is the channel name. see [site_title_tv_guide_channel]",
-      "english": "See all football matches on %@ today and this week. TV schedule with kick-off times for Premier League, Champions League, World Cup and more.",
-      "value": "هەموو یارییەکانی تۆپپێی پێ لەسەر %@ ئەمڕۆ و ئەم هەفتەیە ببینە. خشتەی پەخشی تەلەفیزیۆن بە کاتەکانی دەستپێک بۆ پریمەیەر لیگ، لیگ قهرمانان، جامی جیهان و زیاتر."
+      "english": "See all football matches on %@ today and this week. TV schedule with kick-off times for Premier League, Champions League, World Cup and more."
+      "value": "بینەری هەموو یارییەکانی تۆپی پێ بن لە کەناڵی %1$@ بۆ ئەمڕۆ و ئەم هەفتەیە. خشتەی پەخشی تەلەفزیۆنی لەگەڵ کاتەکانی دەسپێکردنی یارییەکان بۆ خولی نایابی ئینگلیزی، چامپیۆنز لیگ، مۆندیال و چەندینی تر."
     },
     "seo_site_title": {
       "comment": "Title of the site. Typically displayed in the tab header in the browser",
@@ -10895,12 +10975,12 @@
     "seo_site_title_league_matches": {
       "comment": "SEO title for league matches page showing fixtures, results and live scores. First %@ is the league name, second %@ is the season",
       "english": "%1$@ fixtures, results and live scores %2$@",
-      "value": "%1$@ خشتەی یارییەکان، ئەنجامەکان و سکۆری ڕاستەوخۆ %2$@"
+      "value": "خشتەی یارییەکان، ئەنجامەکان و ئەنجامە ڕاستەوخۆکانی %1$@ بۆ وەرزی %2$@"
     },
     "seo_site_title_league_news": {
       "comment": "SEO title for league news page showing latest news and transfer rumours. %@ is the league name",
       "english": "%@ - latest news, transfer rumours and updates",
-      "value": "%@ - دوایین هەواڵەکان، گومانەکانی گواستنەوە و نوێکارییەکان"
+      "value": "خولی ​%1$@ - نوێترین هەواڵەکان، دەنگۆکانی گواستنەوە و گۆڕانکارییەکان"
     },
     "seo_site_title_league_overview": {
       "comment": "Title for the page for a single league or tournament. Containing tables, matches, news and stats for the league. With the league name, and season name as input. Eg \"Premier League matches, tables and news 2021/2022\"",
@@ -10915,7 +10995,7 @@
     "seo_site_title_league_stats": {
       "comment": "SEO title for league stats page showing player and team statistics. First %@ is the league name, second %@ is the season",
       "english": "%1$@ stats for %2$@ - players and teams",
-      "value": "ئاماری %1$@ بۆ %2$@ - یاریزانەکان و تیمەکان"
+      "value": "ئامارەکانی %1$@ بۆ وەرزی %2$@ - یاریزانان و یانەکان"
     },
     "seo_site_title_league_stats_players": {
       "comment": "Title for the page listing the top three players in the league based on different stats. With the league name and season given as input. Eg. \"Premier League 2022/2023 top rated players, goals, assists and other stats\"",
@@ -10930,7 +11010,7 @@
     "seo_site_title_league_stats_trophies": {
       "comment": "SEO title for league trophies page showing past winners and runner-up. %@ is the league name",
       "english": "%@ - past winners, runners-up and title history",
-      "value": "%@ - پاڵەوانەکانی پێشوو، نایب‌پاڵەوانەکان و مێژووی ناونیشان"
+      "value": "خولی %1$@ - پاڵەوانەکانی پێشوو، پلەی دووەمەکان و مێژووی نازناوەکان"
     },
     "seo_site_title_league_table": {
       "comment": "Headline for the league table. Include league name as %1$@ and year indicator as %2$@. Eg \"Premier League table 2021/2022, form and next opponent\"",
@@ -10940,7 +11020,7 @@
     "seo_site_title_league_table_xg": {
       "comment": "SEO title for league xG table page showing expected goals standings. First %@ is the league name, second %@ is the season",
       "english": "%1$@ xG table %2$@ - expected goals standings",
-      "value": "خشتەی xGی %1$@ %2$@ - ڕیزبەندی گۆڵی چاوەڕوانکراو"
+      "value": "خشتەی xG بۆ %1$@ وەرزی %2$@ - ڕیزبەندی گۆڵە چاوەڕوانکراوەکان"
     },
     "seo_site_title_league_transfers": {
       "comment": "Title for the page with the lates transfers to and from clubs playing in the given league. With the name of the league as input.",
@@ -10980,12 +11060,12 @@
     "seo_site_title_team_history": {
       "comment": "SEO title for team history page showing historical table positions and trophies. %@ is the team name",
       "english": "%@ - historical table positions and trophies",
-      "value": "%@ - پۆستەکانی مێژوویی لە خشتە و جامەکان"
+      "value": "​یانەی %1$@ - ڕیزبەندییەکانی پێشوو لە مێژوودا و نازناوەکان"
     },
     "seo_site_title_team_news": {
       "comment": "SEO title for team news page showing latest news and transfer rumours. %@ is the team name",
       "english": "%@ - latest news, transfer rumours and updates",
-      "value": "%@ - دواین هەواڵەکان، دەنگۆی گواستنەوە و نوێکارییەکان"
+      "value": "یانەی %1$@ - نوێترین هەواڵەکان، دەنگۆکانی گواستنەوە و گۆڕانکارییەکان"
     },
     "seo_site_title_team_overview": {
       "comment": "Title for the page for a team or club. With the teams fixtures, standings, transfers, news, top players etc. With the name as input.",
@@ -11000,7 +11080,7 @@
     "seo_site_title_team_stats": {
       "comment": "SEO title for team stats page showing different football statistics. %@ is the team name",
       "english": "%@ - top rated players, goals, assists and other stats",
-      "value": "%@ - یاریزانە هەڵسەنگاندراوەکان، گۆڵەکان، پاس گۆڵەکان و ئامارەکانی دیکە"
+      "value": "یانەی %1$@ - بەرزترین هەڵسەنگاندنی یاریزانان، گۆڵەکان، ئەسیستەکان و ئامارەکانی تر"
     },
     "seo_site_title_team_stats_teams": {
       "comment": "Title for the page showing stats for the entire team compared to other teams. What teams have scored the most goals, keept most clean sheets etc.",
@@ -11010,7 +11090,7 @@
     "seo_site_title_team_table": {
       "comment": "SEO title for team table page showing league standings and form. %@ is the team name",
       "english": "%@ - league table, form guide and next opponent",
-      "value": "%@ - خشتەی لیگ، فۆڕم و ڕکابەری داهاتوو"
+      "value": "یانەی %1$@ - خشتەی خول، دواین ئەنجامەکان و ڕکابەری داهاتوو"
     },
     "seo_site_title_team_transfers": {
       "comment": "Title for the page for a team or clubs transfer history. Showing players transfered in and out. The name is the input with %1$@ as placeholder.",
@@ -11026,6 +11106,11 @@
       "comment": "Meta title tag value for the transfer center page showing only transfers for a spesific team or leage",
       "english": "Transfer Center - %1$@: Latest & Top Transfers - FotMob",
       "value": "ناوەندی گواستنەوە - %1$@: نوێترین و گرنگترین گواستنەوەکان - فوتمۆب"
+    },
+    "seo_site_title_tv_guide": {
+      "comment": "SEO title for tv schedule page of football matches filtered by country. %@ is the country name",
+      "english": "Football TV Schedules in %@ - Watch Live on TV | FotMob",
+      "value": "خشتەی یارییەکانی تۆپی پێ لە %1$@ - بە ڕاستەوخۆ لە تەلەفزیۆن ببینە | فوتمۆب"
     },
     "seo_site_title_tv_guide_channel": {
       "comment": "SEO title for tv schedule page filtered by channel name. %@ is the channel name.",
@@ -11317,6 +11402,11 @@
       "english": "Try our lineup builder",
       "value": "دروستکەری پێکهاتەکەمان تاقیکەرەوە"
     },
+    "seo_tv_guide_country_heading": {
+      "comment": "Page title for TV guide filtered by country. %@ is the country name (e.g., \"Football TV Schedules in United Kingdom\")",
+      "english": "Football TV Schedules in %@",
+      "value": "خشتەی پەخشی یارییەکانی تۆپی پێ لە %@"
+    },
     "seo_tv_guide_matches_date_on": {
       "comment": "Header text for TV guide channel page for football matches. First %@ is the date label (e.g., \"today\", \"tomorrow\", or specific date), second %@ is the channel name. For example in Norwegian it should be \"Kamper i dag på Viaplay\", so: Kamper %@ på %@",
       "english": "Matches %@ on %@",
@@ -11371,7 +11461,7 @@
     "seo_we_have_followed_top_leagues": {
       "comment": "Disclaimer for follow league step in onboarding.",
       "english": "We've followed top leagues for you and you can add more below.",
-      "value": "ئێمە بۆ تۆ پێشتر خولی پێشەنگەکانمان شوێنکەوتووە، دەتوانیت لە خوارەوە زیاتر زیاد بکەیت."
+      "value": "خوولە سەرەکییەکانمان بۆت دیاری کردووە و دەتوانیت لە خوارەوە هی زیاتریش زیاد بکەیت."
     },
     "seo_weather_condition_clear": {
       "comment": "Weather condition for clear night weather (icon codes 31, 33)",


### PR DESCRIPTION
Hi @cnordvik and the FotMob Team,

​First of all, thank you for successfully enabling Kurdish (ckb) support! It’s a great step for the Kurdish community. After a thorough review of the live app, I’ve compiled a list of areas that still need attention to achieve a fully localized and professional experience:

​1. Commentary & 3D Play-by-Play:
Key football terms in the "Commentary" tab (e.g., Goal, Assist, Substitution, Yellow Card) and labels in the 3D Visualizer (e.g., Dangerous Attack, Free Kick, Corner) are still appearing in English. These are core elements of the match experience and need to be localized.

​2. Missing Sections (Predictions & News):
The "FotMob Predictions" feature remains entirely in English. Additionally, some labels and phrases within the "News" section haven't been translated yet.

​3. Country Names:
Some country names are not appearing as they were translated in the ckb.json file. Please ensure the app is pulling these values directly from the provided translation strings to maintain consistency. ​Please let me know if these strings are available in the current files or if they require a separate update. I am ready to provide the correct Kurdish terms for all these sections to ensure the highest quality for our users.

​Best regards,
Sharef Anwar